### PR TITLE
[WIP] Use new solve_ivp for ODE integration.

### DIFF
--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -11,7 +11,7 @@ dependencies:
   - coverage
   - sphinx
   - numpy
-  - scipy
+  - scipy>=1.0
   - matplotlib >=2.1
   - pandas
   - sympy

--- a/user-environment.yml
+++ b/user-environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - setuptools
   - pip
   - numpy
-  - scipy
+  - scipy>=1.0
   - matplotlib >=2.1
   - pandas
   - sympy


### PR DESCRIPTION
Initial working implementation in place. Some notes:

- scipy 1.0 isn't available via conda-forge yet
- All the integrators seem to be either super slow or unstable for the `CoulombPendulumSystem` if you integrate out beyond the sticking point for much time. The fixed time step Runge-Kutta solver we're using currently is nice there though it has accuracy issues. Could just bring that back I suppose.
- Currently the integration method is specified via an attribute on the system class. It should probably at least be a property with a setter that raises an `ValueError` if you try to set it to something not available.
- I think the `ode_func` is intended to always be vectorized, but I'm guessing some fun traceback will result if it's not. Should probably handle that by passing in dummy values when it's set.

Fixes #102 