### PR TITLE
Rolling back dependency requirements to Ubuntu 16.04 LTS versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,8 @@ script:
   # run tests on resonance lib
   - py.test --cov=resonance
   # only build notebooks with latest versions of software
-  - if [[ $DEP_VERSIONS == "latest" ]]; then
+  - |
+    if [[ $DEP_VERSIONS == "latest" ]]; then
       # execute notebooks, convert to html
       bin/execute_notebooks.sh;
       # set up an area for deployed html/ipynb files and push to gh_pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,16 +38,16 @@ script:
   - py.test --cov=resonance
   # only build notebooks with latest versions of software
   - if [[ $DEP_VERSIONS == "latest" ]]; then
-  # execute notebooks, convert to html
-  - bin/execute_notebooks.sh
-  # set up an area for deployed html/ipynb files and push to gh_pages
-  - bin/prepare_deploy.sh
-  - git reset --hard
-  - git clean -Xdf notebooks/
-  - git clean -xdf notebooks/
-  - pip install doctr
-  - doctr deploy --built-docs=deploy/ .
-  - fi
+      # execute notebooks, convert to html
+      bin/execute_notebooks.sh;
+      # set up an area for deployed html/ipynb files and push to gh_pages
+      bin/prepare_deploy.sh;
+      git reset --hard;
+      git clean -Xdf notebooks/;
+      git clean -xdf notebooks/;
+      pip install doctr;
+      doctr deploy --built-docs=deploy/ .;
+    fi
   # try building the documentation
   - cd docs
   - make html

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,8 @@ script:
   - set -e
   # run tests on resonance lib
   - py.test --cov=resonance
+  # only build notebooks with latest versions of software
+  - if [[ $DEP_VERSIONS == "latest" ]]; then
   # execute notebooks, convert to html
   - bin/execute_notebooks.sh
   # set up an area for deployed html/ipynb files and push to gh_pages
@@ -45,6 +47,7 @@ script:
   - git clean -xdf notebooks/
   - pip install doctr
   - doctr deploy --built-docs=deploy/ .
+  - fi
   # try building the documentation
   - cd docs
   - make html

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 language: generic
 os:
   - linux
-
 env:
   global:
     - secure: "M1MRgER9n92ndfjGIwrPmw6wAzVDDzRc01x3kDmbdWJGMlGsuiNvLFcmEQIuE7VUHvaOgqn3G61cAGgisywQvaLnK9+gzizKOIQZeq6wVNaRUvDkP8LufqKE/HgjW3TQfKBOp60dFoKwf7pfyA3oNyA0xQYPSeYBzXuMdnThk5qmYy4i0ciT8wwCVvflA6bBp7GkfjtjzVHZ2HG5kRA+i+isBAMVjD/W3bduJ9LNM9ES/dY/PPgCNSGV0ZrykvRZ5cpqrLCA84ABM9hXDB28+DRnv+qrqvLXtY+2q+jPW7jhZl+9L7UACc/g0h5Mc73FMgc7xDRFbPgc+VbdzHUFlkkc/MahY4xuMIBOAnjcXmWs6H9Mr6dlU+yBJ2VHoThrAdz35X3OKh4Iv1JiFKot5ij9Yfq44fVzgiNNyRoDAne2CuKyHuRmm1NS3dHKrFwelyCR2Q3fLgrlghkX3wihtTMKYR+5/7KQw+f/BQUebiXnEt4IDykr36l/A8HH18nc+dWLDxCxY2uXaaSxZSSdL565S+K5v7KWRxeB48FKdOG86LhChJv4pIHqgPDar2xjhmFcjnCyaV4ROA0IisABTc9iSJGYYNd7k5V8J6gCpuYcgNr7n8Hamp940XxjXPq4DK+z7wT1wXB8gkB9fNcWs2H0cbjXbdnyitYO3RSj4xM="
+  matrix:
+    - DEP_VERSIONS="oldest"  # Approximately the versions available in the last LTS release of Ubuntu.
+    - DEP_VERSIONS="latest"
 install:
   - |
     MINICONDA_URL="https://repo.continuum.io/miniconda"
@@ -14,9 +16,14 @@ install:
   - source ~/miniconda3/bin/activate root
   - conda config --set always_yes yes
   - conda update -q conda
-  - conda env create -f dev-environment.yml
-  - source activate resonance-dev
-  - pip install .
+  - if [[ $DEP_VERSIONS == "oldest" ]]; then
+      conda env create -f dev-oldest-environment.yml;
+      source activate resonance-dev-oldest;
+    elif [[ $DEP_VERSIONS == "latest" ]]; then
+      conda env create -f dev-environment.yml;
+      source activate resonance-dev;
+    fi
+  - python setup.py install
 before_script:
   - conda info
   - conda list

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -4,17 +4,17 @@ channels:
   - defaults
 dependencies:
   - python >=3.5
-  - setuptools
-  - pip
+  - setuptools >=20.7
+  - pip >=8.1
   - pytest
   - pytest-cov
   - coverage
   - sphinx
-  - numpy
-  - scipy
+  - numpy >=1.11
+  - scipy >=0.17
   - matplotlib >=2.1
-  - pandas
-  - sympy
+  - pandas >=0.17
+  - sympy >=0.7.6
   - notebook
   - ipywidgets
   - nbconvert

--- a/dev-oldest-environment.yml
+++ b/dev-oldest-environment.yml
@@ -1,0 +1,21 @@
+name: resonance-dev-oldest
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - python =3.5.*
+  - setuptools =20.7.*
+  - pip =8.1.*
+  - pytest
+  - pytest-cov
+  - coverage
+  - sphinx
+  - numpy =1.11.*
+  - scipy =0.17.*
+  - matplotlib =1.5.*
+  - pandas =0.17.*
+  - sympy =0.7.6.*
+  - notebook
+  - ipywidgets
+  - nbconvert
+  - jupyter_contrib_nbextensions

--- a/resonance/system.py
+++ b/resonance/system.py
@@ -56,11 +56,8 @@ class _StatesDict(_collections.OrderedDict):
             raise ValueError(msg)
 
 
-class _CoordinatesDict(_collections.MutableMapping, dict):
+class _CoordinatesDict(_collections.OrderedDict):
     """A custom dictionary for storing coordinates and speeds."""
-
-    def __getitem__(self, key):
-        return dict.__getitem__(self, key)
 
     def __setitem__(self, key, value):
         # TODO : Shouldn't allow coordinates to be named with suffix _vel.
@@ -77,19 +74,7 @@ class _CoordinatesDict(_collections.MutableMapping, dict):
                    'Choose something different.')
             raise ValueError(msg.format(_FORBIDDEN_SUFFIXES))
         else:
-            dict.__setitem__(self, key, value)
-
-    def __delitem__(self, key):
-        dict.__delitem__(self, key)
-
-    def __iter__(self):
-        return dict.__iter__(self)
-
-    def __len__(self):
-        return dict.__len__(self)
-
-    def __contains__(self, x):
-        return dict.__contains__(self, x)
+            _collections.OrderedDict.__setitem__(self, key, value)
 
 
 class _SingleDoFCoordinatesDict(_CoordinatesDict):

--- a/setup.py
+++ b/setup.py
@@ -15,10 +15,11 @@ setup(
     keywords="engineering vibrations mechanical",
     license='CC-BY 4.0',
     packages=find_packages(),
-    install_requires=['numpy>=1.13',
-                      'matplotlib>=2.1',
-                      'scipy>=0.19',
-                      'pandas>=0.20'],
+    # Try to work with packages in the Ubuntu 16.04 LTS release if possible.
+    install_requires=['numpy>=1.11',
+                      'matplotlib>=1.5',
+                      'scipy>=0.17',
+                      'pandas>=0.17'],
     extras_require={'notebooks': ['notebook', 'ipywidgets']},
     classifiers=[
         'Development Status :: 3 - Alpha',

--- a/user-environment.yml
+++ b/user-environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - pip >=8.1
   - numpy >=1.11
   - scipy >=0.17
-  - matplotlib >=2.1  # required for new rectangle api
+  - matplotlib >=2.1  # required for Rectangle.angle and .to_jshtml()
   - pandas >=0.17
   - sympy >=0.7.6
   - notebook

--- a/user-environment.yml
+++ b/user-environment.yml
@@ -4,13 +4,13 @@ channels:
   - defaults
 dependencies:
   - python >=3.5
-  - setuptools
-  - pip
-  - numpy
-  - scipy
-  - matplotlib >=2.1
-  - pandas
-  - sympy
+  - setuptools >=20.7
+  - pip >=8.1
+  - numpy >=1.11
+  - scipy >=0.17
+  - matplotlib >=2.1  # required for new rectangle api
+  - pandas >=0.17
+  - sympy >=0.7.6
   - notebook
   - ipywidgets
   - jupyter_contrib_nbextensions


### PR DESCRIPTION
This should give a little more flexibility when installing resonance into environments with older versions of some of the dependencies.