### PR TITLE
Just execute notebooks once.

### DIFF
--- a/bin/execute_notebooks.sh
+++ b/bin/execute_notebooks.sh
@@ -9,5 +9,4 @@ fi
 
 for f in notebooks/*.ipynb; do
   jupyter nbconvert --debug --ExecutePreprocessor.enabled=True --ExecutePreprocessor.timeout=300 --to=html "$f"
-  jupyter nbconvert --debug --ExecutePreprocessor.enabled=True --ExecutePreprocessor.timeout=300 --to=notebook "$f"
 done

--- a/bin/prepare_deploy.sh
+++ b/bin/prepare_deploy.sh
@@ -3,7 +3,3 @@ set -x
 mkdir deploy
 cp -R notebooks/* deploy/
 ls -R deploy
-# rename `<notebook>.nbconvert.ipynb` to `<notebook>.ipynb`
-for f in deploy/*.nbconvert.ipynb; do
-    mv "$f" "${f%.nbconvert.ipynb}.ipynb"
-done


### PR DESCRIPTION
Confirmed to work locally, though the main difference is that the ipynb files downloadable from the index file are not executed, which I think is a good thing. If not, we could keep the execute-and-convert-to-ipynb line and change the execute-and-convert-to-html line to just do conversion (which should be fast).

I'd say the downloadable files should ideally have been put through a preprocessor to embed images or turned into zip archives somehow anyway though.

Fixes #122 